### PR TITLE
fix: correct device state handling and harden client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Shared fixtures are in `tests/conftest.py`: `sample_http_data`, `sample_mqtt_dat
 
 ### Manual validation against a live device
 
-`examples/validate.py` connects to the real service and prints parsed device state, useful for sanity-checking changes against actual hardware. Credentials come from the `AQUATLANTIS_USERNAME` / `AQUATLANTIS_PASSWORD` environment variables (never hardcode them). **It must stay strictly read-only — never add `set_*` / power / light calls; this drives a real aquarium.** The only outbound MQTT it should ever produce is the `property.get` request the client issues automatically on `connect()`.
+`examples/validate.py` connects to the real service and prints parsed device state, useful for sanity-checking changes against actual hardware. Credentials come from the `AQUATLANTIS_USERNAME` / `AQUATLANTIS_PASSWORD` environment variables, or a `.env` file in the working directory (`KEY=value` format) — never hardcode them. **It must stay strictly read-only — never add `set_*` / power / light calls; this drives a real aquarium.** The only outbound MQTT it should ever produce is the `property.get` request the client issues automatically on `connect()`.
 
 ### Linting notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ Tests are in `tests/` and split by concern: `test_device.py`, `test_helpers.py`,
 
 Shared fixtures are in `tests/conftest.py`: `sample_http_data`, `sample_mqtt_data`, `sample_online_status_payload`, `sample_offline_status_payload`.
 
+### Manual validation against a live device
+
+`examples/validate.py` connects to the real service and prints parsed device state, useful for sanity-checking changes against actual hardware. Credentials come from the `AQUATLANTIS_USERNAME` / `AQUATLANTIS_PASSWORD` environment variables (never hardcode them). **It must stay strictly read-only — never add `set_*` / power / light calls; this drives a real aquarium.** The only outbound MQTT it should ever produce is the `property.get` request the client issues automatically on `connect()`.
+
 ### Linting notes
 
 Ruff is configured with `select = ["ALL"]` — all rules are enabled by default. Exceptions are documented in `pyproject.toml` (`[tool.ruff.lint.ignore]`). Docstrings follow Google convention. Tests may use assertions (`S101`), access private members (`SLF001`), and magic numbers (`PLR2004`) — these are suppressed per-file.

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -1,0 +1,99 @@
+"""Read-only diagnostic example for the Aquatlantis Ori client.
+
+Connects to the live service and prints the parsed state of every device. It
+NEVER sends control actions (no ``set_*`` / power / light calls); the only
+outbound MQTT is the ``property.get`` request the client issues on connect to
+fetch current state.
+
+Credentials are read from the environment so they are never committed:
+
+    export AQUATLANTIS_USERNAME="you@example.com"
+    export AQUATLANTIS_PASSWORD="your-password"
+    uv run python examples/validate.py
+"""
+
+import asyncio
+import logging
+import os
+import warnings
+
+from aquatlantis_ori import AquatlantisOriClient
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger("validate")
+
+CHANNEL_MIN = 0
+CHANNEL_MAX = 100
+MINUTES_PER_HOUR = 60
+MAX_PLAUSIBLE_OFFSET_HOURS = 14
+
+
+def _check_channel(name: str, value: int | None) -> None:
+    """Print a colour channel value and whether it falls within the documented range."""
+    if value is None:
+        print(f"  {name:7}: None (not reported)")
+        return
+    in_range = CHANNEL_MIN <= value <= CHANNEL_MAX
+    print(f"  {name:7}: {value}  range {CHANNEL_MIN}-{CHANNEL_MAX} {'OK' if in_range else 'OUT OF RANGE'}")
+
+
+async def main() -> None:
+    """Connect read-only and print parsed device state."""
+    username = os.environ.get("AQUATLANTIS_USERNAME")
+    password = os.environ.get("AQUATLANTIS_PASSWORD")
+    if not username or not password:
+        msg = "Set AQUATLANTIS_USERNAME and AQUATLANTIS_PASSWORD environment variables."
+        raise SystemExit(msg)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+
+        async with AquatlantisOriClient(username, password) as client:
+            await client.connect()  # logs in (HTTP), connects MQTT, force_update (property.get)
+
+            # force_update-on-connect: data should arrive without waiting for periodic telemetry.
+            try:
+                await client.wait_for_data(max_wait=10.0)
+                print("[force_update-on-connect] data received within timeout: OK")
+            except TimeoutError:
+                print("[force_update-on-connect] TIMEOUT waiting for first MQTT payload")
+
+            # Read-only HTTP refresh; exercises device_info deserialization.
+            await client.update_devices()
+            print("[update_devices] HTTP refresh + deserialize: OK")
+
+            devices = client.get_devices()
+            print(f"[devices] found {len(devices)}")
+
+            for device in devices:
+                print(f"\n=== {device.name} ({device.devid}) ===")
+                print(f"[availability] status={device.status} availability_state={device.availability_state}")
+
+                print(f"[timeoffset] {device.timeoffset} (minutes)")
+                if device.timeoffset is not None:
+                    hours = device.timeoffset / MINUTES_PER_HOUR
+                    plausible = -MAX_PLAUSIBLE_OFFSET_HOURS <= hours <= MAX_PLAUSIBLE_OFFSET_HOURS
+                    print(f"  => {hours:+.1f}h  {'plausible as minutes' if plausible else 'IMPLAUSIBLE'}")
+
+                print(f"[get_current_timecurve] {device.get_current_timecurve()}")
+                print(f"[is_light_on] power={device.power} mode={device.mode} -> {device.is_light_on}")
+
+                print("[channels]")
+                _check_channel("red", device.red)
+                _check_channel("green", device.green)
+                _check_channel("blue", device.blue)
+                _check_channel("white", device.white)
+                print(f"  intensity: {device.intensity}")
+
+                print("[custom presets]")
+                for idx in (1, 2, 3, 4):
+                    print(f"  custom{idx}: {getattr(device, f'custom{idx}')}")
+
+                print(f"[firmware] installed={device.version} latest={device.latest_firmware_version} name={device.firmware_name}")
+
+    paho_v1 = [str(w.message) for w in caught if "Callback API version 1" in str(w.message)]
+    print(f"\n[paho callback api] deprecated-v1 warnings: {paho_v1 or 'none (VERSION2 OK)'}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/validate.py
+++ b/examples/validate.py
@@ -5,17 +5,18 @@ NEVER sends control actions (no ``set_*`` / power / light calls); the only
 outbound MQTT is the ``property.get`` request the client issues on connect to
 fetch current state.
 
-Credentials are read from the environment so they are never committed:
+Credentials are read from the environment or a ``.env`` file in the working
+directory (``KEY=value`` format, lines starting with ``#`` are ignored):
 
-    export AQUATLANTIS_USERNAME="you@example.com"
-    export AQUATLANTIS_PASSWORD="your-password"
-    uv run python examples/validate.py
+    AQUATLANTIS_USERNAME=you@example.com
+    AQUATLANTIS_PASSWORD=your-password
 """
 
 import asyncio
 import logging
 import os
 import warnings
+from pathlib import Path
 
 from aquatlantis_ori import AquatlantisOriClient
 
@@ -37,8 +38,20 @@ def _check_channel(name: str, value: int | None) -> None:
     print(f"  {name:7}: {value}  range {CHANNEL_MIN}-{CHANNEL_MAX} {'OK' if in_range else 'OUT OF RANGE'}")
 
 
+def _load_dotenv() -> None:
+    """Load KEY=value pairs from .env into the environment (no-op if absent)."""
+    env_file = Path(".env")
+    if not env_file.exists():
+        return
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if line and not line.startswith("#") and "=" in line:
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip())
+
+
 async def main() -> None:
     """Connect read-only and print parsed device state."""
+    _load_dotenv()
     username = os.environ.get("AQUATLANTIS_USERNAME")
     password = os.environ.get("AQUATLANTIS_PASSWORD")
     if not username or not password:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"examples/*.py" = [
+  "INP001",  # These are individual scripts that are not part of the package
+  "T201",  # Allow prints.
+]
 "scripts/*.py" = [
   "INP001",  # These are individual scripts that are not part of the package
   "S603",  # Allow subprocess calls.

--- a/src/aquatlantis_ori/client.py
+++ b/src/aquatlantis_ori/client.py
@@ -80,7 +80,7 @@ class AquatlantisOriClient:
     async def check_firmware_updates(self: Self) -> None:
         """Check for firmware updates for all devices."""
         for device in self._devices:
-            firmware_info = await self._http_client.lastest_firmware(device.brand, device.pkey)
+            firmware_info = await self._http_client.latest_firmware(device.brand, device.pkey)
             if firmware_info.data:
                 device.update_firmware_data(firmware_info.data)
 
@@ -153,25 +153,34 @@ class AquatlantisOriClient:
     def _on_mqtt_connected(self: Self) -> None:
         logger.info("Connected to MQTT broker")
 
+        # Request current state now the connection is up; force_update only publishes while
+        # connected, so requests made during device init are otherwise lost.
+        for device in self._devices:
+            device.force_update()
+
     def _on_mqtt_message(self, message: mqtt.MQTTMessage) -> None:
         """Callback for when a message is received from the MQTT broker."""
         logger.info("Received message on topic %s", message.topic)
 
-        if (
-            message.topic.endswith("/property/sensor/post")
-            or message.topic.endswith("/property/post")
-            or message.topic.endswith("/ota/version")
-            or "/respto/" in message.topic
-        ):
-            # The above topics are used for device state updates and share the same payload structure
-            payload = RetrievePayload.from_json(message.payload.decode("utf-8"))
-            self._update_device_state(payload.devid, payload.param)
-        elif message.topic.endswith("/status"):
-            status_payload = StatusPayload.from_json(message.payload.decode("utf-8"))
-            self._update_device_status(status_payload.devid, status_payload)
-        elif not ("/reqfrom/" in message.topic or "/ntp/" in message.topic or message.topic.endswith("/property/set")):
-            # Log unsupported topics
-            logger.debug("Received message on unsupported topic: %s with payload: %s", message.topic, message.payload.decode("utf-8"))
+        # Runs on paho's network thread: a malformed payload must not escape and break the loop.
+        try:
+            if (
+                message.topic.endswith("/property/sensor/post")
+                or message.topic.endswith("/property/post")
+                or message.topic.endswith("/ota/version")
+                or "/respto/" in message.topic
+            ):
+                # The above topics are used for device state updates and share the same payload structure
+                payload = RetrievePayload.from_json(message.payload.decode("utf-8"))
+                self._update_device_state(payload.devid, payload.param)
+            elif message.topic.endswith("/status"):
+                status_payload = StatusPayload.from_json(message.payload.decode("utf-8"))
+                self._update_device_status(status_payload.devid, status_payload)
+            elif not ("/reqfrom/" in message.topic or "/ntp/" in message.topic or message.topic.endswith("/property/set")):
+                # Log unsupported topics
+                logger.debug("Received message on unsupported topic: %s with payload: %s", message.topic, message.payload.decode("utf-8"))
+        except (ValueError, LookupError, TypeError, UnicodeDecodeError):
+            logger.exception("Failed to process message on topic %s", message.topic)
 
     async def close(self: Self) -> None:
         """Close client."""

--- a/src/aquatlantis_ori/const.py
+++ b/src/aquatlantis_ori/const.py
@@ -3,6 +3,11 @@
 from datetime import timedelta
 from typing import Final
 
+# SECURITY: The reverse-engineered vendor API is reached by bare IP over plaintext
+# HTTP (see http/const.py) and unencrypted MQTT (port 10883). There is no TLS and no
+# server-identity verification, so credentials, the bearer token, and device traffic
+# are exposed to network observers. This is a known limitation imposed by the vendor
+# service; switch to a TLS endpoint here if one becomes available.
 SERVER: Final[str] = "8.209.119.184"
 # Device telemetry arrives roughly every 5 minutes; 6 minutes adds a 1-minute buffer for jitter.
 MQTT_AVAILABILITY_FRESHNESS_WINDOW: Final[timedelta] = timedelta(minutes=6)

--- a/src/aquatlantis_ori/device.py
+++ b/src/aquatlantis_ori/device.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Any, Self
+from typing import Any, Final, Self
 from uuid import UUID
 
 from aquatlantis_ori.const import MQTT_AVAILABILITY_FRESHNESS_WINDOW
@@ -17,6 +17,7 @@ from aquatlantis_ori.helpers import (
     random_id,
     threshold_from_list,
     time_curves_from_list,
+    validate_range,
 )
 from aquatlantis_ori.http.models import LatestFirmwareResponseData, ListAllDevicesResponseDevice
 from aquatlantis_ori.models import (
@@ -36,6 +37,11 @@ from aquatlantis_ori.mqtt.client import AquatlantisOriMQTTClient
 from aquatlantis_ori.mqtt.models import MethodType, MQTTRetrievePayloadParam, MQTTSendPayload, MQTTSendPayloadParam, PropsType, StatusPayload
 
 logger = logging.getLogger(__name__)
+
+INTENSITY_MIN: Final = 0
+INTENSITY_MAX: Final = 100
+CHANNEL_MIN: Final = 0
+CHANNEL_MAX: Final = 100
 
 
 class _MQTTActivitySource(StrEnum):
@@ -84,7 +90,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
     notification_email: str | None = None  # Email address for notifications, if enabled
 
     # Variables from MQTT response
-    timeoffset: int | None = None  # Time offset in seconds
+    timeoffset: int | None = None  # Time offset in minutes, relative to UTC
     rssi: int | None = None  # Signal strength in dBm
     device_time: datetime | None = None  # Device time in UTC
     version: str | None = None  # Firmware version of the device
@@ -369,6 +375,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def set_intensity(self: Self, intensity: int) -> None:
         """Set the light intensity of the device."""
+        validate_range("intensity", intensity, INTENSITY_MIN, INTENSITY_MAX)
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",
             MethodType.PROPERTY_SET,
@@ -377,6 +384,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def set_red(self: Self, red: int) -> None:
         """Set the red color of the device."""
+        validate_range("red", red, CHANNEL_MIN, CHANNEL_MAX)
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",
             MethodType.PROPERTY_SET,
@@ -385,6 +393,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def set_green(self: Self, green: int) -> None:
         """Set the green color of the device."""
+        validate_range("green", green, CHANNEL_MIN, CHANNEL_MAX)
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",
             MethodType.PROPERTY_SET,
@@ -393,6 +402,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def set_blue(self: Self, blue: int) -> None:
         """Set the blue color of the device."""
+        validate_range("blue", blue, CHANNEL_MIN, CHANNEL_MAX)
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",
             MethodType.PROPERTY_SET,
@@ -401,6 +411,7 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
     def set_white(self: Self, white: int) -> None:
         """Set the white color of the device."""
+        validate_range("white", white, CHANNEL_MIN, CHANNEL_MAX)
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",
             MethodType.PROPERTY_SET,
@@ -420,15 +431,15 @@ class Device:  # pylint: disable=too-many-instance-attributes
 
         if options is not None:
             if options.intensity is not None:
-                params["intensity"] = options.intensity
+                params["intensity"] = validate_range("intensity", options.intensity, INTENSITY_MIN, INTENSITY_MAX)
             if options.red is not None:
-                params["ch1brt"] = options.red
+                params["ch1brt"] = validate_range("red", options.red, CHANNEL_MIN, CHANNEL_MAX)
             if options.green is not None:
-                params["ch2brt"] = options.green
+                params["ch2brt"] = validate_range("green", options.green, CHANNEL_MIN, CHANNEL_MAX)
             if options.blue is not None:
-                params["ch3brt"] = options.blue
+                params["ch3brt"] = validate_range("blue", options.blue, CHANNEL_MIN, CHANNEL_MAX)
             if options.white is not None:
-                params["ch4brt"] = options.white
+                params["ch4brt"] = validate_range("white", options.white, CHANNEL_MIN, CHANNEL_MAX)
 
         self._publish(
             f"$username/{self.brand}&{self.pkey}&{self.devid}/property/set",

--- a/src/aquatlantis_ori/helpers.py
+++ b/src/aquatlantis_ori/helpers.py
@@ -11,6 +11,14 @@ def random_id(length: int = 10) -> int:
     return random.randint(10 ** (length - 1), 10**length - 1)  # noqa: S311
 
 
+def validate_range(name: str, value: int, low: int, high: int) -> int:
+    """Validate that a value falls within an inclusive range."""
+    if not low <= value <= high:
+        msg = f"{name} must be between {low} and {high}, got {value}."
+        raise ValueError(msg)
+    return value
+
+
 def ms_timestamp_to_datetime(value: str) -> datetime:
     """Convert a timestamp in milliseconds to a datetime object."""
     return datetime.fromtimestamp(int(value) / 1000, tz=UTC)
@@ -55,11 +63,15 @@ def time_curves_from_list(data: list[int]) -> list[TimeCurve]:
     if not data:
         return []
 
-    # Skip the first item which is the length.
+    count = data[0]
     entries = data[1:]
 
     if len(entries) % 7 != 0:
         msg = "Timecurve data length is not a multiple of 7 after skipping the count."
+        raise ValueError(msg)
+
+    if count != len(entries) // 7:
+        msg = f"Timecurve count ({count}) does not match the number of entries ({len(entries) // 7})."
         raise ValueError(msg)
 
     return [TimeCurve(*entries[i : i + 7]) for i in range(0, len(entries), 7)]
@@ -90,15 +102,11 @@ def light_options_from_list(data: list[int]) -> LightOptions:
         msg = f"Light options data must contain exactly {no_of_fields} elements: [intensity, red, green, blue, white]."
         raise ValueError(msg)
 
-    options = LightOptions()
-    if data[0]:
-        options.intensity = data[0]
-    if data[1]:
-        options.red = data[1]
-    if data[2]:
-        options.green = data[2]
-    if data[3]:
-        options.blue = data[3]
-    if data[4]:
-        options.white = data[4]
-    return options
+    # 0 is a valid value (e.g. a channel turned fully off), so don't filter it out.
+    return LightOptions(
+        intensity=data[0],
+        red=data[1],
+        green=data[2],
+        blue=data[3],
+        white=data[4],
+    )

--- a/src/aquatlantis_ori/http/client.py
+++ b/src/aquatlantis_ori/http/client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
-from json import JSONDecodeError
 from types import TracebackType
 from typing import Self
 
@@ -43,6 +42,7 @@ class AquatlantisOriHTTPClient:
 
     def __init__(self: Self, session: ClientSession | None = None) -> None:
         """Initialize the Aquatlantis Ori HTTP client."""
+        self._token = None
         if session is None:
             self._session = ClientSession()
             self._close_session = True
@@ -100,7 +100,7 @@ class AquatlantisOriHTTPClient:
         )
         return await self._deserialize(response, DeviceInfoResponse)
 
-    async def lastest_firmware(self: Self, brand: str, pkey: str) -> LatestFirmwareResponse:
+    async def latest_firmware(self: Self, brand: str, pkey: str) -> LatestFirmwareResponse:
         """Get the latest firmware version for a given Aquatlantis Ori controller."""
         response = await self._request(
             method=HttpMethod.GET,
@@ -152,7 +152,9 @@ class AquatlantisOriHTTPClient:
         try:
             text = await response.text()
             return model.from_json(text)
-        except JSONDecodeError as exception:
+        except (ValueError, LookupError, TypeError) as exception:
+            # Covers malformed JSON (orjson.JSONDecodeError) and mashumaro schema errors
+            # (MissingField, InvalidFieldValue) raised on unexpected payloads.
             msg = "Failed to deserialize response"
             raise AquatlantisOriDeserializeError(msg) from exception
 

--- a/src/aquatlantis_ori/http/const.py
+++ b/src/aquatlantis_ori/http/const.py
@@ -4,6 +4,8 @@ from enum import StrEnum
 from typing import Final
 
 PORT: Final[int] = 8888
+# SECURITY: plaintext HTTP — login credentials and the bearer token are sent
+# unencrypted. Imposed by the vendor service; see const.SERVER for details.
 PROTOCOL: Final[str] = "http"
 
 

--- a/src/aquatlantis_ori/http/models.py
+++ b/src/aquatlantis_ori/http/models.py
@@ -28,7 +28,7 @@ class AquatlantisOriReponse(DataClassORJSONMixin):
 class DeviceInfoResponse(AquatlantisOriReponse):
     """Device info response model."""
 
-    data: ListAllDevicesResponseDevice
+    data: ListAllDevicesResponseDevice | None
 
 
 @dataclass

--- a/src/aquatlantis_ori/mqtt/client.py
+++ b/src/aquatlantis_ori/mqtt/client.py
@@ -30,7 +30,11 @@ class AquatlantisOriMQTTClient:
         on_message: Callable[[mqtt.MQTTMessage], None] | None = None,
     ) -> None:
         """Initialize the MQTT client."""
-        self._client = mqtt.Client(client_id=client_settings.client_id, protocol=mqtt.MQTTProtocolVersion.MQTTv5)
+        self._client = mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+            client_id=client_settings.client_id,
+            protocol=mqtt.MQTTProtocolVersion.MQTTv5,
+        )
         self._client_settings = client_settings
         self._on_client_connect = on_connect
         self._on_client_message = on_message
@@ -98,6 +102,7 @@ class AquatlantisOriMQTTClient:
         self,
         _client: mqtt.Client,
         _userdata: dict[str, Any],
+        _disconnect_flags: mqtt.DisconnectFlags,
         rc: mqtt.ReasonCode | int | None,
         _properties: mqtt.Properties | None,
     ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,15 +54,15 @@ def fixture_sample_http_data() -> ListAllDevicesResponseDevice:
 def fixture_sample_mqtt_data() -> MQTTRetrievePayloadParam:
     """Create sample MQTT device data."""
     return MQTTRetrievePayloadParam(
-        timeoffset=3600,
+        timeoffset=120,  # +2 hours
         rssi=-45,
         device_time="1719400000000",
         version="1.0.0",
         ssid="TestWiFi",
         ip="192.168.1.100",
         intensity=80,
-        custom1=[75, 255, 128, 64, 200],
-        custom2=[50, 200, 100, 50, 150],
+        custom1=[75, 95, 85, 64, 55],
+        custom2=[50, 70, 100, 50, 60],
         custom3=None,
         custom4=None,
         timecurve=[2, 8, 0, 50, 10, 20, 30, 40, 18, 30, 80, 60, 70, 80, 90],

--- a/tests/http/test_client.py
+++ b/tests/http/test_client.py
@@ -186,10 +186,11 @@ async def test_device_info(monkeypatch: pytest.MonkeyPatch, mock_session: Client
     monkeypatch.setattr(client, "_deserialize", AsyncMock(return_value=response))
     result = await client.device_info("1")
     assert isinstance(result, DeviceInfoResponse)
+    assert result.data is not None
     assert result.data.id == UUID("5202cb6e-8d4f-406d-ad39-f49f82760b39")
 
 
-async def test_lastest_firmware(monkeypatch: pytest.MonkeyPatch, mock_session: ClientSession) -> None:
+async def test_latest_firmware(monkeypatch: pytest.MonkeyPatch, mock_session: ClientSession) -> None:
     """Test latest firmware retrieval."""
     client = AquatlantisOriHTTPClient(session=mock_session)
     client._token = "token"  # noqa: S105
@@ -200,7 +201,7 @@ async def test_lastest_firmware(monkeypatch: pytest.MonkeyPatch, mock_session: C
     mock_response = MagicMock(spec=ClientResponse)
     monkeypatch.setattr(client, "_request", AsyncMock(return_value=mock_response))
     monkeypatch.setattr(client, "_deserialize", AsyncMock(return_value=response))
-    result = await client.lastest_firmware("Aquatlantis", "p")
+    result = await client.latest_firmware("Aquatlantis", "p")
     assert isinstance(result, LatestFirmwareResponse)
     assert result.data
     assert result.data.id == "fw"

--- a/tests/mqtt/test_client.py
+++ b/tests/mqtt/test_client.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _pytest.logging import LogCaptureFixture
 from mashumaro.mixins.orjson import DataClassORJSONMixin
-from paho.mqtt.client import MQTTMessage
+from paho.mqtt.client import DisconnectFlags, MQTTMessage
 
 from aquatlantis_ori.mqtt.client import AquatlantisOriMQTTClient
 from aquatlantis_ori.mqtt.models import MQTTClientSettings
@@ -144,14 +144,14 @@ def test_on_connect_resubscribes_to_known_topics(
 def test_on_disconnect_expected(mqtt_client: AquatlantisOriMQTTClient, mock_mqtt_client: MagicMock, caplog: LogCaptureFixture) -> None:
     """Test that on_disconnect method logs expected messages."""
     with caplog.at_level("INFO"):
-        mqtt_client._on_disconnect(mock_mqtt_client, {}, 0, None)
+        mqtt_client._on_disconnect(mock_mqtt_client, {}, DisconnectFlags(is_disconnect_packet_from_server=False), 0, None)
     assert "Disconnected gracefully" in caplog.text
 
 
 def test_on_disconnect_unexpected(mqtt_client: AquatlantisOriMQTTClient, mock_mqtt_client: MagicMock, caplog: LogCaptureFixture) -> None:
     """Test that on_disconnect method logs unexpected disconnections."""
     with caplog.at_level("WARNING"):
-        mqtt_client._on_disconnect(mock_mqtt_client, {}, 1, None)
+        mqtt_client._on_disconnect(mock_mqtt_client, {}, DisconnectFlags(is_disconnect_packet_from_server=True), 1, None)
     assert "Unexpected disconnection" in caplog.text
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -230,10 +230,15 @@ def test_update_device_status_device_not_found(client: AquatlantisOriClient, cap
 
 
 def test_on_mqtt_connected(client: AquatlantisOriClient, caplog: LogCaptureFixture) -> None:
-    """Test that _on_mqtt_connected logs info message."""
+    """Test that _on_mqtt_connected logs info message and re-issues force_update."""
+    device1 = MagicMock()
+    device2 = MagicMock()
+    client._devices = [device1, device2]
     with caplog.at_level("INFO"):
         client._on_mqtt_connected()
     assert "Connected to MQTT broker" in caplog.text
+    device1.force_update.assert_called_once_with()
+    device2.force_update.assert_called_once_with()
 
 
 def test_on_mqtt_message_sensor_post(client: AquatlantisOriClient) -> None:
@@ -276,6 +281,19 @@ def test_on_mqtt_message_respto(client: AquatlantisOriClient) -> None:
         client._on_mqtt_message(msg)
         from_json.assert_called_once_with("json")
         upd.assert_called_once_with("d", "p")
+
+
+def test_on_mqtt_message_malformed_payload_is_logged(client: AquatlantisOriClient, caplog: LogCaptureFixture) -> None:
+    """A malformed payload must be logged and not propagate out of the callback."""
+    msg = MagicMock()
+    msg.topic = "foo/property/post"
+    msg.payload.decode.return_value = "not-json"
+    with (
+        patch("aquatlantis_ori.mqtt.models.RetrievePayload.from_json", side_effect=ValueError("bad")),
+        caplog.at_level("ERROR"),
+    ):
+        client._on_mqtt_message(msg)
+    assert "Failed to process message" in caplog.text
 
 
 def test_on_mqtt_message_status(client: AquatlantisOriClient) -> None:
@@ -371,7 +389,7 @@ def test_check_firmware_updates(client: AquatlantisOriClient, mock_http_client: 
     firmware_data1 = MagicMock()
     firmware_data2 = MagicMock()
 
-    mock_http_client.lastest_firmware.side_effect = [
+    mock_http_client.latest_firmware.side_effect = [
         MagicMock(data=firmware_data1),
         MagicMock(data=firmware_data2),
     ]

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -130,14 +130,14 @@ def test_update_mqtt_data(
     device = Device(mock_mqtt_client, sample_http_data)
     device.update_mqtt_data(sample_mqtt_data)
 
-    assert device.timeoffset == 3600
+    assert device.timeoffset == 120
     assert device.rssi == -45
     assert device.version == "1.0.0"
     assert device.ssid == "TestWiFi"
     assert device.ip == "192.168.1.100"
     assert device.intensity == 80
-    assert device.custom1 == LightOptions(intensity=75, red=255, green=128, blue=64, white=200)
-    assert device.custom2 == LightOptions(intensity=50, red=200, green=100, blue=50, white=150)
+    assert device.custom1 == LightOptions(intensity=75, red=95, green=85, blue=64, white=55)
+    assert device.custom2 == LightOptions(intensity=50, red=70, green=100, blue=50, white=60)
     assert device.custom3 is None
     assert device.custom4 is None
     assert device.preview == 0
@@ -365,6 +365,40 @@ def test_set_intensity(mock_mqtt_client: MagicMock, sample_http_data: ListAllDev
     assert topic == "$username/Aquatlantis&testpkey&testdevid/property/set"
     assert payload.method == MethodType.PROPERTY_SET
     assert payload.param.intensity == 75
+
+
+def test_set_intensity_out_of_range_raises(mock_mqtt_client: MagicMock, sample_http_data: ListAllDevicesResponseDevice) -> None:
+    """Out-of-range intensity is rejected and nothing is published."""
+    device = Device(mock_mqtt_client, sample_http_data)
+    mock_mqtt_client.reset_mock()
+
+    with pytest.raises(ValueError, match="intensity must be between 0 and 100"):
+        device.set_intensity(150)
+
+    mock_mqtt_client.publish.assert_not_called()
+
+
+@pytest.mark.parametrize("setter", ["set_red", "set_green", "set_blue", "set_white"])
+def test_set_channel_out_of_range_raises(setter: str, mock_mqtt_client: MagicMock, sample_http_data: ListAllDevicesResponseDevice) -> None:
+    """Out-of-range channel values are rejected and nothing is published."""
+    device = Device(mock_mqtt_client, sample_http_data)
+    mock_mqtt_client.reset_mock()
+
+    with pytest.raises(ValueError, match="must be between 0 and 100"):
+        getattr(device, setter)(150)
+
+    mock_mqtt_client.publish.assert_not_called()
+
+
+def test_set_light_out_of_range_raises(mock_mqtt_client: MagicMock, sample_http_data: ListAllDevicesResponseDevice) -> None:
+    """set_light validates option values and publishes nothing when invalid."""
+    device = Device(mock_mqtt_client, sample_http_data)
+    mock_mqtt_client.reset_mock()
+
+    with pytest.raises(ValueError, match="red must be between 0 and 100"):
+        device.set_light(options=LightOptions(red=150))
+
+    mock_mqtt_client.publish.assert_not_called()
 
 
 def test_set_red(mock_mqtt_client: MagicMock, sample_http_data: ListAllDevicesResponseDevice) -> None:
@@ -786,7 +820,7 @@ def test_get_current_timecurve_with_negative_timezone_offset(
     mock_datetime.now.return_value = mock_now
 
     device = Device(mock_mqtt_client, sample_http_data)
-    device.timeoffset = -240  # -4 hours (US EST offset in seconds)
+    device.timeoffset = -240  # -4 hours
     device.timecurve = [
         TimeCurve(hour=8, minute=0, intensity=5, red=5, green=5, blue=5, white=5),
         TimeCurve(hour=12, minute=0, intensity=70, red=30, green=60, blue=80, white=60),

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,6 +13,7 @@ from aquatlantis_ori.helpers import (
     random_id,
     threshold_from_list,
     time_curves_from_list,
+    validate_range,
 )
 from aquatlantis_ori.models import LightOptions, Threshold, TimeCurve
 
@@ -32,6 +33,19 @@ def test_random_id_custom_length(length: int) -> None:
     assert isinstance(result, int)
     assert len(str(result)) == length
     assert 10 ** (length - 1) <= result < 10**length
+
+
+@pytest.mark.parametrize("value", [0, 50, 100])
+def test_validate_range_within_bounds_returns_value(value: int) -> None:
+    """Values within the inclusive range are returned unchanged."""
+    assert validate_range("intensity", value, 0, 100) == value
+
+
+@pytest.mark.parametrize("value", [-1, 101])
+def test_validate_range_out_of_bounds_raises(value: int) -> None:
+    """Values outside the inclusive range raise ValueError."""
+    with pytest.raises(ValueError, match="intensity must be between 0 and 100"):
+        validate_range("intensity", value, 0, 100)
 
 
 def test_ms_timestamp_to_datetime() -> None:
@@ -107,6 +121,12 @@ def test_make_time_curves_invalid_length() -> None:
         time_curves_from_list([2, 1, 2, 3, 4, 5])
 
 
+def test_make_time_curves_count_mismatch() -> None:
+    """Test time_curves_from_list when the declared count does not match the entries."""
+    with pytest.raises(ValueError, match=r"Timecurve count .* does not match the number of entries"):
+        time_curves_from_list([2, 12, 30, 75, 100, 80, 60, 40])
+
+
 def test_make_time_curves_valid() -> None:
     """Test _make_time_curves with valid data."""
     data = [1, 12, 30, 75, 100, 80, 60, 40]
@@ -162,15 +182,26 @@ def test_list_from_time_curves() -> None:
 
 def test_light_options_from_list() -> None:
     """Test light_options_from_list with valid data."""
-    data = [75, 255, 128, 64, 200]
+    data = [75, 95, 85, 64, 55]
     result = light_options_from_list(data)
 
     assert isinstance(result, LightOptions)
     assert result.intensity == 75
-    assert result.red == 255
-    assert result.green == 128
+    assert result.red == 95
+    assert result.green == 85
     assert result.blue == 64
-    assert result.white == 200
+    assert result.white == 55
+
+
+def test_light_options_from_list_preserves_zero() -> None:
+    """Zero is a valid value (e.g. a channel turned fully off) and must not be dropped."""
+    result = light_options_from_list([0, 50, 0, 0, 0])
+
+    assert result.intensity == 0
+    assert result.red == 50
+    assert result.green == 0
+    assert result.blue == 0
+    assert result.white == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change

A full review of the library surfaced several correctness bugs, robustness gaps, and doc/reality inconsistencies. This PR fixes them, adds input validation, and ships a read-only diagnostic example. All changes were verified against a live device (read-only) in addition to the test suite.

**Bug fixes**

- **Preserve `0` in custom presets** — `helpers.light_options_from_list` used truthiness checks, so a channel set to `0` (a valid "off") was dropped to `None`. It now assigns values directly. `Device.custom1`–`custom4` therefore expose `0` instead of `None` for an off channel.
- **`_token` initialized** — `AquatlantisOriHTTPClient.__init__` now sets `self._token = None`. Previously the attribute was only annotated, so any call before `login()` (e.g. `logout()`, `list_all_devices()`) raised `AttributeError` instead of a clean state.
- **`force_update` re-issued on connect** — the state request made during `Device.__init__` could be dropped if it ran before the MQTT connection was fully established. `_on_mqtt_connected` now re-requests state for all devices, so `wait_for_data()` resolves promptly instead of waiting for the ~5-minute telemetry cycle. Also covers reconnects.
- **MQTT callback hardened** — `_on_mqtt_message` runs on paho's network thread; a malformed/unexpected payload previously raised straight into that loop. Parsing is now wrapped and logged.
- **Broader deserialize handling** — `AquatlantisOriHTTPClient._deserialize` now also wraps mashumaro schema errors (`MissingField`, `InvalidFieldValue`, …) as `AquatlantisOriDeserializeError`, not just malformed JSON.

**Hardening / API**

- **Setter validation** — `set_intensity` (0–100) and `set_red`/`set_green`/`set_blue`/`set_white` plus `set_light` options (0–100) now validate via a shared `helpers.validate_range`. Out-of-range values raise `ValueError` **before** anything is published.
- **`DeviceInfoResponse.data` is now optional** (`| None`), matching the other response models and the existing `if device_info.data:` guard.
- **paho Callback API v2** — the MQTT client now passes `CallbackAPIVersion.VERSION2` (and the updated `_on_disconnect` signature), moving off the deprecated v1 path. Verified against the live broker: no deprecation warning.
- **Timecurve count validation** — `time_curves_from_list` now checks the declared count against the actual number of parsed entries.
- **Typo fix** — `AquatlantisOriHTTPClient.lastest_firmware` → `latest_firmware`.

**Docs / inconsistencies**

- `timeoffset` comment corrected to **minutes** (the code already used `timedelta(minutes=...)`; confirmed against a live device reporting `60` → UTC+1).
- Colour-channel docstrings corrected to **0–100** (per `docs/MQTT.md`; the live device confirms channels never exceed 100).
- Documented the plaintext-HTTP / unencrypted-MQTT / no-TLS limitation in `const.py` and `http/const.py` as a known vendor-imposed risk.

**Tooling**

- Added `examples/validate.py`: a strictly read-only diagnostic that connects, fetches current state, and prints it. Credentials are read from `AQUATLANTIS_USERNAME` / `AQUATLANTIS_PASSWORD` env vars or a `.env` file in the working directory (`KEY=value` format) — never hardcoded. Added a matching `examples/*.py` ruff per-file-ignore.

Verification: `pytest` (145 passing, 100% coverage), `mypy`, `ruff check`, `ruff format`, and `pylint` (10/10) all green; pre-commit hooks pass.

## Breaking change

Yes — labelled `breaking-change`. Consumers may need to adjust:

1. **Setters raise on invalid input.** `set_intensity`, `set_red`/`green`/`blue`/`white`, and `set_light` now raise `ValueError` for values outside 0–100 instead of silently publishing them. Callers passing out-of-range values must clamp/validate first or handle the exception.
2. **Custom presets expose `0` instead of `None`.** A channel that is off in `Device.custom1`–`custom4` is now `0` rather than `None`. Code that treated `None` as "off" should treat `0` as a valid value.
3. **Method rename.** `AquatlantisOriHTTPClient.lastest_firmware` → `latest_firmware`. (This class is not part of the public `__init__` surface, but direct users of it must update the call.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)